### PR TITLE
Switch back to the old repo push format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  GH_TOKEN: ${{ secrets.REPO_PAT }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,4 +50,6 @@ jobs:
           make_latest: true
       - name: Add to repo
         run: |
-          curl -u "${{ secrets.APT_CREDENTIALS }}" -H "Content-Type: multipart/form-data" --data-binary "@${{ steps.build_deb.outputs.file_name }}" "https://repo.andrew-stclair.com/repository/apt-hosted/"
+          REF=$(echo "${{ github.ref }}" | cut -d '/' -f3 | sed 's/v//g')
+          REF_V=$(echo "${{ github.ref }}" | cut -d '/' -f3)
+          gh workflow run import.yaml --repo andrew-stclair/repo.andrew-stclair.com --field package=https://github.com/andrew-stclair/ufw-applications/releases/download/${REF_V}/ufw-applications_${REF}_all.deb


### PR DESCRIPTION
Switching back to the format used when updating a GitHub repo, rather than trying to upload to Nexus Repo Manager